### PR TITLE
capitalizing 'Equal' in 'isEqual'

### DIFF
--- a/src/Service/ApiService.js
+++ b/src/Service/ApiService.js
@@ -1,4 +1,4 @@
-const isEqual = require('lodash/isequal');
+const isEqual = require('lodash/isEqual');
 const isPromise = require('is-promise');
 const isEmpty = require('lodash/isEmpty');
 const ApiError = require('../Error/ApiError.js');


### PR DESCRIPTION
Fixes bug on Linux because of strict case sensitivity